### PR TITLE
refactor: consolidate vendor data into a single shared source of truth

### DIFF
--- a/src/components/AdminTab.js
+++ b/src/components/AdminTab.js
@@ -26,6 +26,7 @@ import DashboardSkeleton from './DashboardSkeleton';
 import * as firebaseService from '../services/firebase';
 import RechartsCharts from './SimpleChart';
 import { calculateDriverFare } from '../utils/calculateDriverFare';
+import { VENDOR_CATALOG } from '../constants/vendors';
 
 const GOOGLE_SHEET_URL = "https://docs.google.com/spreadsheets/d/1PydOwXd4EA_pp6g3AB0-E1dYvXHY768h/edit?usp=sharing&ouid=102038458839648014695&rtpof=true&sd=true";
 
@@ -151,23 +152,15 @@ const [addHistoryForm, setAddHistoryForm] = useState({
   profit: ''
 });
 
-  const VENDOR_MAP = {
-  'mixue': { name: 'Mixue', icon: '🧋' },
-  'dominos': { name: 'Dominos', icon: '🍕' },
-  'ayam_gepuk': { name: 'Ayam Gepuk', icon: '🍗' },
-  'family_mart': { name: 'Family Mart', icon: '🏪' },
-  'bakers_cottage': { name: 'Baker\'s Cottage', icon: '🥐' },
-  'zus_coffee': { name: 'Zus Coffee', icon: '☕' },
-  'kfc': { name: 'KFC', icon: '🍗' },
-  'mcd': { name: "McDonald's", icon: '🍔' },
-  'douglas_street': { name: 'The Douglas Street', icon: '🍽️' },
-};
+  const VENDOR_MAP = Object.fromEntries(
+    Object.entries(VENDOR_CATALOG).map(([id, v]) => [id, { name: v.name, icon: v.icon }])
+  );
 
-  const VENDOR_CATEGORIES = {
-    'mixue': 1, 'dominos': 1, 'ayam_gepuk': 1, 'bakers_cottage': 1,
-    'family_mart': 2,
-    'zus_coffee': 3,
-  };
+  const VENDOR_CATEGORIES = Object.fromEntries(
+    Object.entries(VENDOR_CATALOG)
+      .filter(([, v]) => v.category != null)
+      .map(([id, v]) => [id, v.category])
+  );
 
   const calculateSuggestedDriverCost = (orders) => {
     if (!orders || orders.length === 0) return 0;

--- a/src/components/DriverTab.js
+++ b/src/components/DriverTab.js
@@ -18,17 +18,12 @@ import {
 
 import AuthScreen from './AuthScreen';
 import DashboardSkeleton from './DashboardSkeleton';
+import { VENDOR_CATALOG } from '../constants/vendors';
 
 const VENDOR_DATA = {
-  dominos: { name: "Domino's", color: '#006491', backgroundColor: '#E5F0F4' },
-  ayam_gepuk: { name: "Ayam Gepuk Pak Gembus", color: '#f1af20ff', backgroundColor: '#FFDBCF' },
-  mixue: { name: 'Mixue', color: '#ef0a0aff', backgroundColor: '#F9EBEB' },
-  family_mart: { name: 'Family Mart', color: '#00642e', backgroundColor: '#E6F5EC' },
-  bakers_cottage: { name: 'Baker\'s Cottage', color: '#92400e', backgroundColor: '#FEF3C7' },
-  zus_coffee: { name: 'Zus Coffee', color: '#003a71', backgroundColor: '#E0EFFF' },
-  kfc: { name: 'KFC', color: '#e4002b', backgroundColor: '#FCE4E7' },
-  mcd: { name: "McDonald's", color: '#946200', backgroundColor: '#FFF6DC' },
-  douglas_street: { name: 'The Douglas Street', color: '#374151', backgroundColor: '#F1F5F9' },
+  ...Object.fromEntries(
+    Object.entries(VENDOR_CATALOG).map(([id, v]) => [id, { name: v.name, color: v.driverTagColor, backgroundColor: v.driverTagBg }])
+  ),
   default: { name: 'Unknown Store', color: '#475569', backgroundColor: '#F1F5F9', logoUrl: '' }
 };
 

--- a/src/components/LandingPage.js
+++ b/src/components/LandingPage.js
@@ -11,23 +11,34 @@ import zusCoffeeLogo from '../assets/merchant_logo/Zus Coffee.png';
 import kfcLogo from '../assets/merchant_logo/KFC.png';
 import mcdLogo from '../assets/merchant_logo/Mcd.png';
 import douglasStreetLogo from '../assets/merchant_logo/The Douglas Street.jpg';
+import { VENDOR_CATALOG } from '../constants/vendors';
+
+const VENDOR_LOGO_IMAGES = {
+  mcd: mcdLogo,
+  douglas_street: douglasStreetLogo,
+  kfc: kfcLogo,
+  dominos: dominosLogo,
+  ayam_gepuk: ayamGepukLogo,
+  mixue: mixueLogo,
+  family_mart: familyMartLogo,
+  bakers_cottage: bakersCottageLogo,
+  zus_coffee: zusCoffeeLogo,
+};
+
+// Display order on the landing page (McDonald's stays in place, first,
+// for whenever VENDOR_CATALOG.mcd.enabled flips back to true).
+const VENDOR_DISPLAY_ORDER = ['mcd', 'douglas_street', 'kfc', 'dominos', 'ayam_gepuk', 'mixue', 'family_mart', 'bakers_cottage', 'zus_coffee'];
 
 const LandingPage = ({ onStart, onNavigateToPortal, windowWidth }) => {
   const [selectedVendor, setSelectedVendor] = useState('');
   const [isStaffMenuOpen, setIsStaffMenuOpen] = useState(false);
 
-  const vendors = [
-    // TEMP: McDonald's disabled, re-add when back in service
-    // { id: 'mcd', name: "McDonald's", logo: '🍔', logoImage: mcdLogo, color: '#ffc72c' },
-    { id: 'douglas_street', name: 'The Douglas Street', logo: '🍽️', logoImage: douglasStreetLogo, color: '#4b5563' },
-    { id: 'kfc', name: 'KFC', logo: '🍗', logoImage: kfcLogo, color: '#e4002b' },
-    { id: 'dominos', name: "Domino's Pizza", logo: '🍕', logoImage: dominosLogo, color: '#0078d4' },
-    { id: 'ayam_gepuk', name: "Ayam Gepuk Pak Gembus", logo: '🍗', logoImage: ayamGepukLogo, color: '#ffcc02' },
-    { id: 'mixue', name: 'MIXUE', logo: '🧋', logoImage: mixueLogo, color: '#ff69b4' },
-    { id: 'family_mart', name: 'Family Mart', logo: '🏪', logoImage: familyMartLogo, color: '#009a44' },
-    { id: 'bakers_cottage', name: 'Baker\'s Cottage', logo: '🥐', logoImage: bakersCottageLogo, color: '#D97706' },
-    { id: 'zus_coffee', name: 'Zus Coffee', logo: '☕', logoImage: zusCoffeeLogo, color: '#0057A0' }
-  ];
+  const vendors = VENDOR_DISPLAY_ORDER
+    .filter((id) => VENDOR_CATALOG[id].enabled)
+    .map((id) => {
+      const v = VENDOR_CATALOG[id];
+      return { id, name: v.landingName || v.name, logo: v.icon, logoImage: VENDOR_LOGO_IMAGES[id], color: v.selectionColor };
+    });
 
   const foodItems = [
     { emoji: '🍔' }, { emoji: '🍕' }, { emoji: '🍟' }, { emoji: '🧋' },

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -1,21 +1,20 @@
 import React, { useState } from 'react';
 import { Users, Truck, BarChart3, Menu, X, Home, BookOpen, Heart } from 'lucide-react';
 import logo from '../assets/logo(1).png';
+import { VENDOR_CATALOG } from '../constants/vendors';
 
 // --- THIS IS THE CRITICAL FIX ---
 // Define VENDORS as a constant OUTSIDE the component.
 // This object is created only once and is always up-to-date.
-const VENDORS = {
-    'mixue': { name: 'Mixue', icon: '🧋', shortName: 'Mixue' },
-    'dominos': { name: 'Dominos', icon: '🍕', shortName: 'Dominos' },
-    'ayam_gepuk': { name: "Ayam Gepuk", icon: '🍗', shortName: "Ayam Gepuk" },
-    'family_mart': { name: 'Family Mart', icon: '🏪', shortName: 'Family Mart' },
-    'bakers_cottage': { name: 'Baker\'s Cottage', icon: '🥐', shortName: 'Bakers Cottage' },
-    'zus_coffee': { name: 'Zus Coffee', icon: '☕', shortName: 'Zus Coffee' },
-    'kfc': { name: 'KFC', icon: '🍗', shortName: 'KFC' },
-    'mcd': { name: "McDonald's", icon: '🍔', shortName: "McDonald's" },
-    'douglas_street': { name: 'The Douglas Street', icon: '🍽️', shortName: 'Douglas St.' },
+// A couple of vendors get an even shorter label on narrow screens (<=480px);
+// everyone else's shortName just falls back to their regular name.
+const NAV_MOBILE_SHORT_NAME = {
+    bakers_cottage: 'Bakers Cottage',
+    douglas_street: 'Douglas St.',
 };
+const VENDORS = Object.fromEntries(
+    Object.entries(VENDOR_CATALOG).map(([id, v]) => [id, { name: v.name, icon: v.icon, shortName: NAV_MOBILE_SHORT_NAME[id] || v.name }])
+);
 
 // A fallback for any case where the vendor might not be found.
 const FALLBACK_VENDOR = { name: 'Select Vendor', icon: '🏪', shortName: 'Vendor' };

--- a/src/components/StudentTab.js
+++ b/src/components/StudentTab.js
@@ -11,6 +11,11 @@ import UnifiedQRCodeDisplay from './UnifiedQRCodeDisplay';
 import imageCompression from 'browser-image-compression';
 import LoadingAnimation from './LoadingAnimation';
 import deliveryAnimation from '../assets/mascot.mp4';
+import { VENDOR_CATALOG } from '../constants/vendors';
+
+// Display order for the merchant-selection grid (McDonald's stays in place,
+// second-to-last, for whenever VENDOR_CATALOG.mcd.enabled flips back to true).
+const STUDENT_VENDOR_ORDER = ['dominos', 'ayam_gepuk', 'mixue', 'family_mart', 'bakers_cottage', 'zus_coffee', 'kfc', 'mcd', 'douglas_street'];
 
 const StudentTab = ({
   prebookUsers,
@@ -1696,18 +1701,13 @@ const isSubmitDisabled =
               gap: '12px',
               marginBottom: '8px'
             }}>
-              {[
-                { id: 'dominos', name: "Domino's Pizza", emoji: '🍕', color: '#0078d4' },
-                { id: 'ayam_gepuk', name: "Ayam Gepuk Pak Gembus", emoji: '🍗', color: '#ffcc02' },
-                { id: 'mixue', name: 'MIXUE', emoji: '🧋', color: '#ff69b4' },
-                { id: 'family_mart', name: 'Family Mart', emoji: '🏪', color: '#009a44' },
-                { id: 'bakers_cottage', name: 'Baker\'s Cottage', emoji: '🥐', color: '#D97706' },
-                { id: 'zus_coffee', name: 'Zus Coffee', emoji: '☕', color: '#0057A0' },
-                { id: 'kfc', name: 'KFC', emoji: '🍗', color: '#e4002b' },
-                // TEMP: McDonald's disabled, re-add when back in service
-                // { id: 'mcd', name: "McDonald's", emoji: '🍔', color: '#ffc72c' },
-                { id: 'douglas_street', name: 'The Douglas Street', emoji: '🍽️', color: '#4b5563' }
-              ].map((vendor) => (
+              {STUDENT_VENDOR_ORDER
+                .filter((id) => VENDOR_CATALOG[id].enabled)
+                .map((id) => {
+                  const v = VENDOR_CATALOG[id];
+                  return { id, name: v.name, emoji: v.icon, color: v.selectionColor };
+                })
+                .map((vendor) => (
                 <div
                   key={vendor.id}
                   onClick={() => setSelectedVendor(vendor.id)}
@@ -2012,15 +2012,7 @@ const isSubmitDisabled =
             }}>
               <div style={{ fontSize: '13px', color: '#64748b', fontWeight: '600' }}>Merchant</div>
               <div style={{ fontSize: '15px', fontWeight: '700', color: '#1e293b' }}>
-                {selectedVendor === 'dominos' && "🍕 Domino's Pizza"}
-                {selectedVendor === 'ayam_gepuk' && "🍗 Ayam Gepuk"}
-                {selectedVendor === 'mixue' && "🧋 MIXUE"}
-                {selectedVendor === 'family_mart' && "🏪 Family Mart"}
-                {selectedVendor === 'bakers_cottage' && "🥐 Baker's Cottage"}
-                {selectedVendor === 'zus_coffee' && "☕ Zus Coffee"}
-                {selectedVendor === 'kfc' && "🍗 KFC"}
-                {selectedVendor === 'mcd' && "🍔 McDonald's"}
-                {selectedVendor === 'douglas_street' && "🍽️ The Douglas Street"}
+                {selectedVendor && VENDOR_CATALOG[selectedVendor] && `${VENDOR_CATALOG[selectedVendor].icon} ${VENDOR_CATALOG[selectedVendor].name}`}
               </div>
             </div>
             

--- a/src/constants/vendors.js
+++ b/src/constants/vendors.js
@@ -1,0 +1,113 @@
+// Single source of truth for vendor data. Add/edit a vendor here only —
+// every screen (Navigation, Admin, Driver, Landing Page, Student ordering,
+// driver fare calculation) reads from this file instead of its own copy.
+//
+// Field guide:
+// - name: short display name, used everywhere except the landing page.
+// - landingName: full/long display name, shown only on the landing page
+//   (there's room there; other screens are short on space).
+// - icon: emoji used across all screens.
+// - enabled: whether a student can pick this vendor for a NEW order.
+//   Disabled vendors are still kept in this file (with real data) so
+//   past orders placed under them still display correctly everywhere —
+//   only the two vendor-picker screens (Landing Page, Student ordering)
+//   filter on this flag. Flip it back to true to bring a vendor back
+//   everywhere at once.
+// - selectionColor: accent color used on the vendor-picker cards
+//   (Landing Page and Student ordering).
+// - driverTagColor / driverTagBg: colors for the vendor tag pill shown
+//   in the Driver tab.
+// - category: used only for AdminTab's suggested-driver-cost grouping.
+//   Vendors without a category are excluded from that grouping (matches
+//   existing behavior — kfc/mcd/douglas_street were never categorized).
+// - surcharge: per-vendor surcharge added in calculateDriverFare.js.
+//   Vendors without one contribute 0.
+
+export const VENDOR_CATALOG = {
+  mixue: {
+    name: 'MIXUE',
+    icon: '🧋',
+    enabled: true,
+    selectionColor: '#ff69b4',
+    driverTagColor: '#ef0a0aff',
+    driverTagBg: '#F9EBEB',
+    category: 1,
+    surcharge: 1,
+  },
+  dominos: {
+    name: "Domino's",
+    landingName: "Domino's Pizza",
+    icon: '🍕',
+    enabled: true,
+    selectionColor: '#0078d4',
+    driverTagColor: '#006491',
+    driverTagBg: '#E5F0F4',
+    category: 1,
+  },
+  ayam_gepuk: {
+    name: 'Ayam Gepuk',
+    landingName: 'Ayam Gepuk Pak Gembus',
+    icon: '🍗',
+    enabled: true,
+    selectionColor: '#ffcc02',
+    driverTagColor: '#f1af20ff',
+    driverTagBg: '#FFDBCF',
+    category: 1,
+  },
+  family_mart: {
+    name: 'Family Mart',
+    icon: '🏪',
+    enabled: true,
+    selectionColor: '#009a44',
+    driverTagColor: '#00642e',
+    driverTagBg: '#E6F5EC',
+    category: 2,
+    surcharge: 2,
+  },
+  bakers_cottage: {
+    name: "Baker's Cottage",
+    icon: '🥐',
+    enabled: true,
+    selectionColor: '#D97706',
+    driverTagColor: '#92400e',
+    driverTagBg: '#FEF3C7',
+    category: 1,
+  },
+  zus_coffee: {
+    name: 'Zus Coffee',
+    icon: '☕',
+    enabled: true,
+    selectionColor: '#0057A0',
+    driverTagColor: '#003a71',
+    driverTagBg: '#E0EFFF',
+    category: 3,
+    surcharge: 3,
+  },
+  kfc: {
+    name: 'KFC',
+    icon: '🍗',
+    enabled: true,
+    selectionColor: '#e4002b',
+    driverTagColor: '#e4002b',
+    driverTagBg: '#FCE4E7',
+    surcharge: 3,
+  },
+  mcd: {
+    name: "McDonald's",
+    icon: '🍔',
+    enabled: false, // TEMP: disabled everywhere it's selectable — flip to true to bring it back
+    selectionColor: '#ffc72c',
+    driverTagColor: '#946200',
+    driverTagBg: '#FFF6DC',
+    surcharge: 2,
+  },
+  douglas_street: {
+    name: 'The Douglas Street',
+    icon: '🍽️',
+    enabled: true,
+    selectionColor: '#4b5563',
+    driverTagColor: '#374151',
+    driverTagBg: '#F1F5F9',
+    surcharge: 3,
+  },
+};

--- a/src/utils/calculateDriverFare.js
+++ b/src/utils/calculateDriverFare.js
@@ -1,20 +1,18 @@
 // src/utils/calculateDriverFare.js
 // TEMPORARY driver-fare formula. Does NOT replace calculateDeliveryFee.js
 // (the student-facing delivery fee) — this only calculates what the driver is paid.
+import { VENDOR_CATALOG } from '../constants/vendors';
 
 const BASE_FARE = 30;
 const MAX_FARE = 59;
 
 // Surcharge applied once per DISTINCT vendor visited that day (not per order).
-const VENDOR_SURCHARGE = {
-  mixue: 1,
-  family_mart: 2,
-  mcd: 2,
-  kfc: 3,
-  douglas_street: 3,
-  zus_coffee: 3,
-  // dominos, ayam_gepuk, bakers_cottage: no surcharge
-};
+// dominos, ayam_gepuk, bakers_cottage have no surcharge entry in the catalog.
+const VENDOR_SURCHARGE = Object.fromEntries(
+  Object.entries(VENDOR_CATALOG)
+    .filter(([, v]) => v.surcharge != null)
+    .map(([id, v]) => [id, v.surcharge])
+);
 
 // Only the highest-qualifying bonus applies (checked highest-first).
 const BONUS_TIERS = [


### PR DESCRIPTION
Vendor names, icons, and colors were previously hardcoded independently in 7 places (Navigation, AdminTab, DriverTab, LandingPage, StudentTab x2, calculateDriverFare), which had already drifted out of sync (inconsistent Domino's/Ayam Gepuk naming, McDonald's enabled in some places but not others). Adding a vendor required editing 5+ files.

Introduces src/constants/vendors.js as the single catalog every file now derives from. Also adds an `enabled` flag so a vendor can be disabled or re-enabled everywhere at once instead of commenting out each screen's copy individually.

Verified via automated field-by-field comparison against the original per-file values: no unintended output changes, only the naming inconsistencies explicitly reviewed and approved (Mixue -> MIXUE, Domino's spelling, Ayam Gepuk short/full form).